### PR TITLE
Support for node 10

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -5,6 +5,9 @@ var util = require('util');
 var PassThrough = require('readable-stream').PassThrough;
 var _ = require('lodash');
 
+// Some versions of node populate _headers while others
+// populate a symbol key (node10+)
+var outHeadersKey = readOutHeadersKey();
 
 /**
  * Mock request object for sending to the router without needing a server.
@@ -20,6 +23,7 @@ var MockRequest = function (options) {
   this.httpVersion = '1.1';
   this.url = options.url || '/';
   this.query = url.parse(this.url, true).query;
+  this[outHeadersKey] = null;
   this.headers = this._headers = {};
 
   // necessary for mocking a real request.
@@ -29,7 +33,9 @@ var MockRequest = function (options) {
   // setHeader now applies toLowerCase the names to mirror native node behaviour
   var self = this;
   _.each(options.headers, function (v, k) {
-    self.setHeader(k, v);
+    if (v !== undefined) {
+      self.setHeader(k, v);
+    }
   });
 
   this.setHeader('transfer-encoding', 'chunked');
@@ -58,7 +64,7 @@ MockRequest.prototype.setHeader = function (name, value, clobber) {
     if (http.ClientRequest.prototype.getHeaders) {
       this.headers = http.ClientRequest.prototype.getHeaders.call(this);
     } else {
-      this.headers = this._headers;
+      this.headers = this[outHeadersKey];
     }
     return ret;
   } else if (clobber || !this.headers.hasOwnProperty(name)) {
@@ -75,5 +81,23 @@ MockRequest.prototype.getHeader = function (name) {
     return this.headers[name];
   }
 };
+
+function readOutHeadersKey() {
+  if (http.ClientRequest && Object.getOwnPropertySymbols) {
+    var x = {};
+    try {
+      http.ClientRequest.apply(x);
+    } catch (e) {
+      // This will invariably throw
+    }
+    var symbols = Object.getOwnPropertySymbols(x);
+    for (var i = 0; i < symbols.length; i++) {
+      if (symbols[i].toString() == 'Symbol(outHeadersKey)') {
+        return symbols[i];
+      }
+    }
+  }
+  return '_headers';
+}
 
 module.exports = MockRequest;

--- a/lib/response.js
+++ b/lib/response.js
@@ -16,17 +16,6 @@ var MockResponse = function (callback) {
   this.buffer = [];
   this.statusCode = 200;
   this._headers = {};
-  this.on('data', function (chunk) {
-    this.buffer.push(chunk);
-  });
-  this.on('pipe', function (src) {
-    var buffer = this.buffer;
-
-    src.on('data', function (chunk) {
-      buffer.push(chunk);
-    })
-  });
-  this.on('close', function () {});
 
   if (callback) {
     var self = this;

--- a/lib/response.js
+++ b/lib/response.js
@@ -3,6 +3,10 @@ var util = require('util');
 var http = require('http');
 var Buffer = require('buffer').Buffer;
 
+// Some versions of node populate _headers while others
+// populate a symbol key (node10+)
+var outHeadersKey = readOutHeadersKey();
+
 /**
  * Mock response object for receiving content without a server.
  **/
@@ -15,6 +19,7 @@ var MockResponse = function (callback) {
 
   this.buffer = [];
   this.statusCode = 200;
+  this[outHeadersKey] = null;
   this._headers = {};
 
   if (callback) {
@@ -53,7 +58,7 @@ MockResponse.prototype.setHeader = function (name, value, clobber) {
     if (http.ServerResponse.prototype.getHeaders) {
       this.headers = http.ServerResponse.prototype.getHeaders.call(this);
     } else {
-      this.headers = this._headers;
+      this.headers = this[outHeadersKey];
     }
     return ret;
   } else if (clobber || !this.headers.hasOwnProperty(name)) {
@@ -79,18 +84,25 @@ MockResponse.prototype.end = function (str) {
   }
   
   var body = this._buildBody();
+  var headers;
+
+  if (http.ServerResponse.prototype.getHeaders) {
+    headers = http.ServerResponse.prototype.getHeaders.call(this);
+  } else {
+    headers = this[outHeadersKey];
+  }
 
   this.emit('close');
   this.emit('finish');
   this.emit('end', null, { // deprecate me
     statusCode: this.statusCode,
     body: body,
-    headers: this._headers
+    headers: headers
   });
   this.emit('response', null, {
     statusCode: this.statusCode,
     body: body,
-    headers: this._headers
+    headers: headers
   });
   this.finished = true
 
@@ -119,5 +131,24 @@ MockResponse.prototype._buildBody = function _buildBody() {
 
   return Buffer.concat(this.buffer);
 };
+
+function readOutHeadersKey() {
+  if (http.ServerResponse && Object.getOwnPropertySymbols) {
+    var x = {};
+    try {
+      http.ServerResponse.apply(x);
+    } catch (e) {
+      // This will invariably throw
+    }
+    var symbols = Object.getOwnPropertySymbols(x);
+    for (var i = 0; i < symbols.length; i++) {
+      if (symbols[i].toString() == 'Symbol(outHeadersKey)') {
+        return symbols[i];
+      }
+    }
+  }
+  return '_headers';
+}
+
 
 module.exports = MockResponse;


### PR DESCRIPTION
I wanted to share with you this change I am working with locally to add support for node 10.

This fixes the issue with double-emission https://github.com/doanythingfordethklok/hammock/issues/21 but breaks back-compat with node 0.8, so a major version bump is recommended if this change is accepted.

This also updates for changes to how headers are stored (symbol based key) in node 10+.