### PR TITLE
correct README details

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,26 +6,28 @@ Node.js mock / polyfill http object library for http req / res.
 
 Polyfill req / res for testing w/o http or for code generation from an existing site. Since the purpose of this lib is mock req/res for testing, you probably want this as a dev dependency. I think I've used it in a production app for something like SSR or something, but it was unusual!!! 
 
-# Install - Node 10+
-Node 8 and Node 10 have some incompatible differences so only use the latest version for node 10. 
+# Install Node (0.10+)
 
 ```
-npm install hammock --dev
+npm install hammock --save-dev
 
 OR 
 
 yarn add hammock --dev
 ```
 
-# Install - Node 8 
-Use v2 for Node 8
+# Install - Node (0.8 compatibility)
+
+Hammock v3 breaks backwards compatibility for node 0.8 which
+will not affect the vast majority of users. For those still
+using 0.8, use major version 2.
 
 ```
-npm install hammock@v2.2.0  --dev
+npm install hammock@^2.2.0 --save-dev
 
 OR 
 
-yarn add hammock@v2.2.0  --dev
+yarn add hammock@v2.2.0 --dev
 ```
 
 


### PR DESCRIPTION
I have edited the README just to clarify. v3 only breaks back compat for the very old 0.8 version of node, and it works with later versions. 0.10, 0.11, 0.12, iojs, 4, 5, 6, 7, 8, 9, 10, 11